### PR TITLE
Update async version

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "author": "IBM",
   "license": "SEE LICENSE IN LICENSE.txt",
   "dependencies": {
-    "async": "^1.5.2",
+    "async": "^2.6.4",
     "bunyan": "^1.7.0",
     "http-auth": "~2.4.11",
     "yamljs": "^0.2.4"


### PR DESCRIPTION
Async version `1.5.2` is vulnerable to CVE-2021-43138 to move to the latest safe version.